### PR TITLE
Fix for Prototype Pollution

### DIFF
--- a/set.js
+++ b/set.js
@@ -11,6 +11,7 @@ module.exports = function set(reference, pathParts, value) {
 
     for(; index < pathLength; index++){
         var key = pathParts[index];
+        if (isPrototypePolluted(key)) return false;
 
         if ((typeof result !== 'object' || result === null) && index < pathLength) {
             if (typeof key !== 'symbol' && !Number.isNaN(Number(key))) {
@@ -30,3 +31,6 @@ module.exports = function set(reference, pathParts, value) {
         }
     }
 };
+function isPrototypePolluted(key) {
+	return ['__proto__', 'prototype', 'constructor'].includes(key);
+  }


### PR DESCRIPTION
### 📊 Metadata *

`unbox` is vulnerable to `Prototype Pollution`.
This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-unbox/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:

```
// poc.js
var unbox = require("unbox")
var myObject = {}
console.log("Before : " + {}.polluted);
unbox.set(myObject, '__proto__.polluted', 'Yes! Its Polluted');
console.log("After : " + {}.polluted);
```

2. Execute the following commands in another terminal:

```bash
npm i unbox # Install affected module
node poc.js #  Run the PoC
```

3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```


### 🔥 Proof of Fix (PoF) *

After fix execution will block prototype pollution and polluted will be [undefined.]



### 👍 User Acceptance Testing (UAT)

After fix functionality is unaffected.